### PR TITLE
wire some stuff up

### DIFF
--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
@@ -301,6 +301,7 @@ public class DatasourceOptimizerTest extends CuratorTestBase
         EasyMock.createMock(QueryToolChestWarehouse.class),
         EasyMock.createMock(QueryWatcher.class),
         getSmileMapper(),
+        new DefaultObjectMapper(),
         EasyMock.createMock(HttpClient.class)
     );
 

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -424,4 +424,19 @@ public interface QueryMetrics<QueryType extends Query<?>>
    * Emits all metrics, registered since the last {@code emit()} call on this QueryMetrics object.
    */
   void emit(ServiceEmitter emitter);
+
+  default void addDiagnostic(String identifier, Object value)
+  {
+    // no op
+  }
+
+  default void addDiagnosticMeasurement(String identifier, Number value)
+  {
+    // no op
+  }
+
+  default void addChildDiagnostic(QueryRuntimeAnalysis child)
+  {
+    // no op
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryRuntimeAnalysis.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryRuntimeAnalysis.java
@@ -10,28 +10,29 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.query.filter.Filter;
 import org.joda.time.Interval;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class QueryRuntimeAnalysis<QueryType extends Query<?>, V extends QueryMetrics<QueryType> > implements QueryMetrics<QueryType>
 {
   protected V delegate;
-  protected Map<String, Object> debugInfo;
-  protected Map<String, Number> metrics;
-  protected List<QueryRuntimeAnalysis> children;
+  protected ConcurrentMap<String, Object> debugInfo;
+  protected ConcurrentMap<String, Number> metrics;
+  protected ConcurrentLinkedQueue<QueryRuntimeAnalysis> children;
 
   public QueryRuntimeAnalysis(V delegate)
   {
     this.delegate = delegate;
-    this.debugInfo = new HashMap<>();
-    this.metrics = new HashMap<>();
-    this.children = new ArrayList<>();
+    this.debugInfo = new ConcurrentHashMap<>();
+    this.metrics = new ConcurrentHashMap<>();
+    this.children = new ConcurrentLinkedQueue<>();
   }
 
   @JsonCreator
@@ -42,9 +43,9 @@ public class QueryRuntimeAnalysis<QueryType extends Query<?>, V extends QueryMet
   )
   {
     this.delegate = null;
-    this.debugInfo = debugInfo;
-    this.metrics = metrics;
-    this.children = children;
+    this.debugInfo = new ConcurrentHashMap<>(debugInfo);
+    this.metrics = new ConcurrentHashMap<>(metrics);
+    this.children = new ConcurrentLinkedQueue<>(children);
   }
 
   /**
@@ -447,7 +448,7 @@ public class QueryRuntimeAnalysis<QueryType extends Query<?>, V extends QueryMet
   }
 
   @JsonProperty
-  public List<QueryRuntimeAnalysis> getChildren()
+  public ConcurrentLinkedQueue<QueryRuntimeAnalysis> getChildren()
   {
     return children;
   }

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -726,7 +726,10 @@ public class CachingClusteredClient implements QuerySegmentWalker
               Queries.withSpecificSegments(queryPlus.getQuery(), segmentsOfServer)
           ).withMaxQueuedBytes(maxQueuedBytesPerServer),
           responseContext
-      );
+      ).withBaggage(() -> {
+
+        System.out.println(responseContext.getQueryMetrics().toString());
+      });
     }
 
     private Sequence<T> getAndCacheServerResults(

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClientFactory.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClientFactory.java
@@ -22,6 +22,7 @@ package org.apache.druid.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import org.apache.druid.guice.annotations.EscalatedClient;
+import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.http.client.HttpClient;
@@ -37,6 +38,7 @@ public class DirectDruidClientFactory
   private final QueryToolChestWarehouse warehouse;
   private final QueryWatcher queryWatcher;
   private final ObjectMapper smileMapper;
+  private final ObjectMapper jsonMapper;
   private final HttpClient httpClient;
 
   @Inject
@@ -45,6 +47,7 @@ public class DirectDruidClientFactory
       final QueryToolChestWarehouse warehouse,
       final QueryWatcher queryWatcher,
       final @Smile ObjectMapper smileMapper,
+      final @Json ObjectMapper jsonMapper,
       final @EscalatedClient HttpClient httpClient
   )
   {
@@ -52,6 +55,7 @@ public class DirectDruidClientFactory
     this.warehouse = warehouse;
     this.queryWatcher = queryWatcher;
     this.smileMapper = smileMapper;
+    this.jsonMapper = jsonMapper;
     this.httpClient = httpClient;
   }
 
@@ -61,6 +65,7 @@ public class DirectDruidClientFactory
         warehouse,
         queryWatcher,
         smileMapper,
+        jsonMapper,
         httpClient,
         server.getScheme(),
         server.getHost(),

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -42,7 +42,6 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.QueryPlus;
-import org.apache.druid.query.QueryRuntimeAnalysis;
 import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.query.QueryToolChest;
@@ -63,7 +62,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
-
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -187,8 +185,7 @@ public class QueryLifecycle
               }
             }
         ),
-        queryResponse.getResponseContext(),
-        queryResponse.getQueryRuntimeAnalysis()
+        queryResponse.getResponseContext()
     );
   }
 
@@ -285,11 +282,8 @@ public class QueryLifecycle
 
     @SuppressWarnings("unchecked")
     final Sequence<T> res = queryPlus.run(texasRanger, responseContext);
-    final QueryRuntimeAnalysis runtimeAnalysis = (responseContext.getQueryMetrics() instanceof QueryRuntimeAnalysis) ?
-                                                 (QueryRuntimeAnalysis) responseContext.getQueryMetrics() :
-                                                 null;
 
-    return new QueryResponse<T>(res == null ? Sequences.empty() : res, responseContext, runtimeAnalysis);
+    return new QueryResponse<T>(res == null ? Sequences.empty() : res, responseContext);
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -131,6 +131,11 @@ public class QueryLifecycle
     this.startNs = startNs;
   }
 
+  public long getStartNs()
+  {
+    return startNs;
+  }
+
   /**
    * For callers who have already authorized their query, and where simplicity is desired over flexibility. This method
    * does it all in one call. Logs and metrics are emitted when the Sequence is either fully iterated or throws an

--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -583,6 +583,12 @@ public class QueryResource implements QueryCountStatsProvider
     }
 
     @Override
+    public long getStartNs()
+    {
+      return queryLifecycle.getStartNs();
+    }
+
+    @Override
     public void writeException(Exception e, OutputStream out) throws IOException
     {
       final ObjectWriter objectWriter = queryLifecycle.newOutputWriter(io);

--- a/server/src/main/java/org/apache/druid/server/QueryResponse.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResponse.java
@@ -20,28 +20,22 @@
 package org.apache.druid.server;
 
 import org.apache.druid.java.util.common.guava.Sequence;
-import org.apache.druid.query.QueryRuntimeAnalysis;
 import org.apache.druid.query.context.ResponseContext;
-
-import javax.annotation.Nullable;
 
 public class QueryResponse<T>
 {
   private final Sequence<T> results;
   private final ResponseContext responseContext;
 
-  private final QueryRuntimeAnalysis queryRuntimeAnalysis;
-
-  public QueryResponse(final Sequence<T> results, final ResponseContext responseContext, QueryRuntimeAnalysis queryRuntimeAnalysis)
+  public QueryResponse(final Sequence<T> results, final ResponseContext responseContext)
   {
     this.results = results;
     this.responseContext = responseContext;
-    this.queryRuntimeAnalysis = queryRuntimeAnalysis;
   }
 
   public static <T> QueryResponse<T> withEmptyContextAndDebugInfo(Sequence<T> results)
   {
-    return new QueryResponse<T>(results, ResponseContext.createEmpty(), null);
+    return new QueryResponse<T>(results, ResponseContext.createEmpty());
   }
 
   public Sequence<T> getResults()
@@ -52,11 +46,5 @@ public class QueryResponse<T>
   public ResponseContext getResponseContext()
   {
     return responseContext;
-  }
-
-  @Nullable
-  public QueryRuntimeAnalysis getQueryRuntimeAnalysis()
-  {
-    return queryRuntimeAnalysis;
   }
 }

--- a/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
@@ -642,6 +642,7 @@ public class BrokerServerViewTest extends CuratorTestBase
         EasyMock.createMock(QueryToolChestWarehouse.class),
         EasyMock.createMock(QueryWatcher.class),
         getSmileMapper(),
+        new DefaultObjectMapper(),
         EasyMock.createMock(HttpClient.class)
     );
 

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -60,6 +60,7 @@ import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.sql.http.SqlQuery;
 import org.apache.druid.sql.http.SqlResource;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
@@ -577,6 +578,19 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   {
     StandardResponseHeaderFilterHolder.deduplicateHeadersInProxyServlet(proxyResponse, serverResponse);
     super.onServerResponseHeaders(clientRequest, proxyResponse, serverResponse);
+  }
+
+  @Override
+  protected void onProxyResponseSuccess(
+      HttpServletRequest clientRequest,
+      HttpServletResponse proxyResponse,
+      Response serverResponse
+  )
+  {
+    if (proxyResponse instanceof org.eclipse.jetty.server.Response && serverResponse instanceof HttpResponse) {
+      ((org.eclipse.jetty.server.Response) proxyResponse).setTrailers(() -> ((HttpResponse) serverResponse).getTrailers());
+    }
+    super.onProxyResponseSuccess(clientRequest, proxyResponse, serverResponse);
   }
 
   @VisibleForTesting

--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -66,6 +66,11 @@ public class SqlExecutionReporter
     this.startNs = System.nanoTime();
   }
 
+  public long getStartNs()
+  {
+    return startNs;
+  }
+
   public void failed(Throwable e)
   {
     this.e = e;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionRel.java
@@ -111,7 +111,7 @@ public class DruidUnionRel extends DruidRel<DruidUnionRel>
   {
     // Lazy: run each query in sequence, not all at once.
     if (limit == 0) {
-      return new QueryResponse<Object[]>(Sequences.empty(), ResponseContext.createEmpty(), null);
+      return new QueryResponse<>(Sequences.empty(), ResponseContext.createEmpty());
     } else {
 
       // We run the first rel here for two reasons:
@@ -149,8 +149,7 @@ public class DruidUnionRel extends DruidRel<DruidUnionRel>
       final Sequence returnSequence = Sequences.concat(recombinedSequences);
       return new QueryResponse<Object[]>(
           limit > 0 ? returnSequence.limit(limit) : returnSequence,
-          queryResponse.getResponseContext(),
-          queryResponse.getQueryRuntimeAnalysis()
+          queryResponse.getResponseContext()
       );
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeQueryMaker.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeQueryMaker.java
@@ -253,8 +253,7 @@ public class NativeQueryMaker implements QueryMaker
               return newArray;
             }
         ),
-        results.getResponseContext(),
-        results.getQueryRuntimeAnalysis()
+        results.getResponseContext()
     );
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -333,6 +333,12 @@ public class SqlResource
     }
 
     @Override
+    public long getStartNs()
+    {
+      return stmt.reporter().getStartNs();
+    }
+
+    @Override
     public void writeException(Exception ex, OutputStream out) throws IOException
     {
       if (ex instanceof SanitizableException) {


### PR DESCRIPTION
ugly but kind of works (well, only for native queries)
```json
{
  "debugInfo": {
    "duration": "PT9223372036854775.807S",
    "sqlQueryId": "95a691fb-7656-496c-9468-c32235de4430",
    "hasFilters": "false",
    "context": {
      "arrayIngestMode": "array",
      "debug": true,
      "populateCache": false,
      "queryId": "95a691fb-7656-496c-9468-c32235de4430",
      "sqlQueryId": "95a691fb-7656-496c-9468-c32235de4430",
      "useApproximateTopN": false,
      "useCache": false,
      "useNativeQueryExplain": true
    },
    "subQueries": [
      "95a691fb-7656-496c-9468-c32235de4430"
    ],
    "interval": [
      "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
    ],
    "id": "95a691fb-7656-496c-9468-c32235de4430",
    "type": "groupBy",
    "dataSource": "wikipedia-schemaless"
  },
  "metrics": {
    "query/time": 30,
    "query/cpu/time": 2577
  },
  "children": [
    {
      "debugInfo": {
        "duration": "PT54000S",
        "vectorized": true,
        "server": "localhost:8083",
        "sqlQueryId": "95a691fb-7656-496c-9468-c32235de4430",
        "hasFilters": "false",
        "segment": "wikipedia-schemaless_2015-09-12T23:00:00.000Z_2015-09-13T00:00:00.000Z_2022-12-20T04:00:08.712Z_8",
        "context": {
          "applyLimitPushDown": false,
          "arrayIngestMode": "array",
          "debug": true,
          "defaultTimeout": 300000,
          "finalize": false,
          "fudgeTimestamp": "-4611686018427387904",
          "groupByOutermost": false,
          "maxQueuedBytes": 85899345,
          "maxScatterGatherBytes": 9223372036854775807,
          "mergeRunnersUsingChainedExecution": true,
          "populateCache": false,
          "queryFailTime": 1703020138686,
          "queryId": "95a691fb-7656-496c-9468-c32235de4430",
          "resultAsArray": true,
          "sqlQueryId": "95a691fb-7656-496c-9468-c32235de4430",
          "timeout": 299999,
          "useApproximateTopN": false,
          "useCache": false,
          "useNativeQueryExplain": true
        },
        "subQueries": [
          "95a691fb-7656-496c-9468-c32235de4430"
        ],
        "interval": [
          "2015-09-12T01:00:00.000Z/2015-09-12T02:00:00.000Z",
          "2015-09-12T03:00:00.000Z/2015-09-12T05:00:00.000Z",
          "2015-09-12T06:00:00.000Z/2015-09-12T11:00:00.000Z",
          "2015-09-12T13:00:00.000Z/2015-09-12T17:00:00.000Z",
          "2015-09-12T20:00:00.000Z/2015-09-12T22:00:00.000Z",
          "2015-09-12T23:00:00.000Z/2015-09-13T00:00:00.000Z"
        ],
        "id": "95a691fb-7656-496c-9468-c32235de4430",
        "type": "groupBy",
        "dataSource": "wikipedia-schemaless"
      },
      "metrics": {
        "query/time": 19,
        "query/node/time": 21,
        "query/segment/time": 1,
        "query/wait/time": 13,
        "query/segmentAndCache/time": 2,
        "query/node/ttfb": 20,
        "query/node/bytes": 39
      },
      "children": []
    },
    {
      "debugInfo": {
        "duration": "PT32400S",
        "vectorized": true,
        "server": "localhost:8084",
        "sqlQueryId": "95a691fb-7656-496c-9468-c32235de4430",
        "hasFilters": "false",
        "segment": "wikipedia-schemaless_2015-09-12T22:00:00.000Z_2015-09-12T23:00:00.000Z_2022-12-20T04:00:08.670Z_8",
        "context": {
          "applyLimitPushDown": false,
          "arrayIngestMode": "array",
          "debug": true,
          "defaultTimeout": 300000,
          "finalize": false,
          "fudgeTimestamp": "-4611686018427387904",
          "groupByOutermost": false,
          "maxQueuedBytes": 85899345,
          "maxScatterGatherBytes": 9223372036854775807,
          "mergeRunnersUsingChainedExecution": true,
          "populateCache": false,
          "queryFailTime": 1703020138684,
          "queryId": "95a691fb-7656-496c-9468-c32235de4430",
          "resultAsArray": true,
          "sqlQueryId": "95a691fb-7656-496c-9468-c32235de4430",
          "timeout": 299998,
          "useApproximateTopN": false,
          "useCache": false,
          "useNativeQueryExplain": true
        },
        "subQueries": [
          "95a691fb-7656-496c-9468-c32235de4430"
        ],
        "interval": [
          "2015-09-12T00:00:00.000Z/2015-09-12T01:00:00.000Z",
          "2015-09-12T02:00:00.000Z/2015-09-12T03:00:00.000Z",
          "2015-09-12T05:00:00.000Z/2015-09-12T06:00:00.000Z",
          "2015-09-12T11:00:00.000Z/2015-09-12T13:00:00.000Z",
          "2015-09-12T17:00:00.000Z/2015-09-12T20:00:00.000Z",
          "2015-09-12T22:00:00.000Z/2015-09-12T23:00:00.000Z"
        ],
        "id": "95a691fb-7656-496c-9468-c32235de4430",
        "type": "groupBy",
        "dataSource": "wikipedia-schemaless"
      },
      "metrics": {
        "query/time": 24,
        "query/node/time": 25,
        "query/segment/time": 1,
        "query/wait/time": 19,
        "query/segmentAndCache/time": 1,
        "query/node/ttfb": 25,
        "query/node/bytes": 48
      },
      "children": []
    }
  ]
}
```